### PR TITLE
fix: use timezone-aware datetimes for --older-than filtering

### DIFF
--- a/killpy/commands/delete.py
+++ b/killpy/commands/delete.py
@@ -30,7 +30,7 @@ def _filter_envs(
     if older_than is not None:
         cutoff = now - timedelta(days=older_than)
         result = [
-            e for e in result if e.last_accessed.replace(tzinfo=timezone.utc) < cutoff
+            e for e in result if e.last_accessed < cutoff
         ]
 
     return result

--- a/killpy/commands/list.py
+++ b/killpy/commands/list.py
@@ -30,7 +30,7 @@ def _filter_envs(
     if older_than is not None:
         cutoff = now - timedelta(days=older_than)
         result = [
-            e for e in result if e.last_accessed.replace(tzinfo=timezone.utc) < cutoff
+            e for e in result if e.last_accessed < cutoff
         ]
 
     return result

--- a/killpy/detectors/artifacts.py
+++ b/killpy/detectors/artifacts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from killpy.detectors.base import AbstractDetector
@@ -49,12 +49,15 @@ class ArtifactsDetector(AbstractDetector):
                     try:
                         stat = artifact_path.stat()
                         size = get_total_size(artifact_path)
+                        mtime = datetime.fromtimestamp(
+                            stat.st_mtime, tz=timezone.utc,
+                        )
                         envs.append(
                             Environment(
                                 path=artifact_path,
                                 name=str(artifact_path),
                                 type="artifacts",
-                                last_accessed=datetime.fromtimestamp(stat.st_mtime),
+                                last_accessed=mtime,
                                 size_bytes=size,
                             )
                         )

--- a/killpy/detectors/cache.py
+++ b/killpy/detectors/cache.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from killpy.detectors.base import AbstractDetector
@@ -89,10 +89,11 @@ class CacheDetector(AbstractDetector):
 def _make_cache_env(p: Path, tag: str) -> Environment:
     stat = p.stat()
     size = get_total_size(p)
+    mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
     return Environment(
         path=p,
         name=str(p),
         type=tag,
-        last_accessed=datetime.fromtimestamp(stat.st_mtime),
+        last_accessed=mtime,
         size_bytes=size,
     )

--- a/killpy/detectors/conda.py
+++ b/killpy/detectors/conda.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import shutil
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from killpy.detectors.base import AbstractDetector
@@ -64,12 +64,15 @@ class CondaDetector(AbstractDetector):
             try:
                 stat = env_path.stat()
                 size = get_total_size(env_path)
+                mtime = datetime.fromtimestamp(
+                    stat.st_mtime, tz=timezone.utc,
+                )
                 envs.append(
                     Environment(
                         path=env_path,
                         name=env_name,
                         type="conda",
-                        last_accessed=datetime.fromtimestamp(stat.st_mtime),
+                        last_accessed=mtime,
                         size_bytes=size,
                         managed_by="conda",
                     )

--- a/killpy/detectors/hatch.py
+++ b/killpy/detectors/hatch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import platform
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from killpy.detectors.base import AbstractDetector
@@ -55,12 +55,15 @@ class HatchDetector(AbstractDetector):
                     try:
                         stat = env_dir.stat()
                         size = get_total_size(env_dir)
+                        mtime = datetime.fromtimestamp(
+                            stat.st_mtime, tz=timezone.utc,
+                        )
                         envs.append(
                             Environment(
                                 path=env_dir,
                                 name=f"{project_dir.name}/{env_dir.name}",
                                 type="hatch",
-                                last_accessed=datetime.fromtimestamp(stat.st_mtime),
+                                last_accessed=mtime,
                                 size_bytes=size,
                             )
                         )

--- a/killpy/detectors/pipenv.py
+++ b/killpy/detectors/pipenv.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import platform
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from killpy.detectors.base import AbstractDetector
@@ -48,12 +48,15 @@ class PipenvDetector(AbstractDetector):
                 try:
                     stat = venv_path.stat()
                     size = get_total_size(venv_path)
+                    mtime = datetime.fromtimestamp(
+                        stat.st_mtime, tz=timezone.utc,
+                    )
                     envs.append(
                         Environment(
                             path=venv_path,
                             name=venv_path.name,
                             type="pipenv",
-                            last_accessed=datetime.fromtimestamp(stat.st_mtime),
+                            last_accessed=mtime,
                             size_bytes=size,
                         )
                     )

--- a/killpy/detectors/pipx.py
+++ b/killpy/detectors/pipx.py
@@ -7,7 +7,7 @@ import logging
 import platform
 import shutil
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from killpy.detectors.base import AbstractDetector
@@ -97,12 +97,15 @@ class PipxDetector(AbstractDetector):
             try:
                 stat = candidate.stat()
                 size = get_total_size(candidate)
+                mtime = datetime.fromtimestamp(
+                    stat.st_mtime, tz=timezone.utc,
+                )
                 envs.append(
                     Environment(
                         path=candidate,
                         name=package_name,
                         type="pipx",
-                        last_accessed=datetime.fromtimestamp(stat.st_mtime),
+                        last_accessed=mtime,
                         size_bytes=size,
                         managed_by="pipx",
                     )

--- a/killpy/detectors/poetry.py
+++ b/killpy/detectors/poetry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import platform
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from killpy.detectors.base import AbstractDetector
@@ -48,12 +48,15 @@ class PoetryDetector(AbstractDetector):
                 try:
                     stat = venv_path.stat()
                     size = get_total_size(venv_path)
+                    mtime = datetime.fromtimestamp(
+                        stat.st_mtime, tz=timezone.utc,
+                    )
                     envs.append(
                         Environment(
                             path=venv_path,
                             name=venv_path.name,
                             type="poetry",
-                            last_accessed=datetime.fromtimestamp(stat.st_mtime),
+                            last_accessed=mtime,
                             size_bytes=size,
                         )
                     )

--- a/killpy/detectors/pyenv.py
+++ b/killpy/detectors/pyenv.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import platform
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from killpy.detectors.base import AbstractDetector
@@ -49,12 +49,15 @@ class PyenvDetector(AbstractDetector):
                 try:
                     stat = version_dir.stat()
                     size = get_total_size(version_dir)
+                    mtime = datetime.fromtimestamp(
+                        stat.st_mtime, tz=timezone.utc,
+                    )
                     envs.append(
                         Environment(
                             path=version_dir,
                             name=version_dir.name,
                             type="pyenv",
-                            last_accessed=datetime.fromtimestamp(stat.st_mtime),
+                            last_accessed=mtime,
                             size_bytes=size,
                         )
                     )

--- a/killpy/detectors/tox.py
+++ b/killpy/detectors/tox.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from killpy.detectors.base import AbstractDetector
@@ -37,12 +37,15 @@ class ToxDetector(AbstractDetector):
                     try:
                         stat = tox_path.stat()
                         size = get_total_size(tox_path)
+                        mtime = datetime.fromtimestamp(
+                            stat.st_mtime, tz=timezone.utc,
+                        )
                         envs.append(
                             Environment(
                                 path=tox_path,
                                 name=str(tox_path),
                                 type="tox",
-                                last_accessed=datetime.fromtimestamp(stat.st_mtime),
+                                last_accessed=mtime,
                                 size_bytes=size,
                             )
                         )

--- a/killpy/detectors/uv.py
+++ b/killpy/detectors/uv.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from killpy.detectors.base import AbstractDetector
@@ -43,12 +43,15 @@ class UvDetector(AbstractDetector):
                     try:
                         stat = uv_path.stat()
                         size = get_total_size(uv_path)
+                        mtime = datetime.fromtimestamp(
+                            stat.st_mtime, tz=timezone.utc,
+                        )
                         envs.append(
                             Environment(
                                 path=uv_path,
                                 name=str(uv_path),
                                 type="uv",
-                                last_accessed=datetime.fromtimestamp(stat.st_mtime),
+                                last_accessed=mtime,
                                 size_bytes=size,
                             )
                         )

--- a/killpy/detectors/venv.py
+++ b/killpy/detectors/venv.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from killpy.detectors.base import AbstractDetector
@@ -101,10 +101,11 @@ class VenvDetector(AbstractDetector):
 def _make_env(dir_path: Path, tag: str) -> Environment:
     stat = dir_path.stat()
     size = get_total_size(dir_path)
+    mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
     return Environment(
         path=dir_path,
         name=str(dir_path),
         type=tag,
-        last_accessed=datetime.fromtimestamp(stat.st_mtime),
+        last_accessed=mtime,
         size_bytes=size,
     )

--- a/tests/unit/test_cleaner.py
+++ b/tests/unit/test_cleaner.py
@@ -6,7 +6,7 @@ the tests never touch the real filesystem or spawn subprocesses.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch, call
 
@@ -31,7 +31,7 @@ def _env(
         path=path or Path("/fake/env"),
         name=name,
         type=env_type,
-        last_accessed=datetime(2024, 6, 1),
+        last_accessed=datetime(2024, 6, 1, tzinfo=timezone.utc),
         size_bytes=size,
         managed_by=managed_by,
     )

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -7,7 +7,7 @@ stubs ``Scanner`` / ``Cleaner`` to avoid real filesystem scans.
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -33,7 +33,7 @@ def _env(
         path=path or Path("/fake/myenv"),
         name=name,
         type=env_type,
-        last_accessed=datetime(2024, 3, 15),
+        last_accessed=datetime(2024, 3, 15, tzinfo=timezone.utc),
         size_bytes=size,
         managed_by=managed_by,
     )
@@ -236,9 +236,8 @@ class TestDeleteFilters:
         assert result.exit_code == 0
 
     def test_older_than_filter(self) -> None:
-        from datetime import datetime, timezone
         old = _env(name="old", env_type="venv")
-        # last_accessed is datetime(2024, 3, 15) — more than 30 days ago relative to test run
+        # last_accessed is datetime(2024, 3, 15, tzinfo=utc) — more than 30 days ago
         result = self._run_delete(["--older-than", "1", "--yes"], [old])
         assert result.exit_code == 0
 

--- a/tests/unit/test_scanner.py
+++ b/tests/unit/test_scanner.py
@@ -6,7 +6,7 @@ filesystem access is required.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -26,7 +26,7 @@ def _make_env(path: Path, env_type: str = "venv", size: int = 1024) -> Environme
         path=path,
         name=path.name,
         type=env_type,
-        last_accessed=datetime(2024, 1, 1),
+        last_accessed=datetime(2024, 1, 1, tzinfo=timezone.utc),
         size_bytes=size,
     )
 


### PR DESCRIPTION
## Summary

All 11 detectors create `last_accessed` timestamps via `datetime.fromtimestamp(stat.st_mtime)`, which produces naive (timezone-unaware) datetimes in the local timezone. The `--older-than` filter in `list` and `delete` then compares these against `datetime.now(tz=timezone.utc)` (line 23 in both files), patching them with `.replace(tzinfo=timezone.utc)` -- which reinterprets the local time as if it were UTC rather than converting it.

This causes `--older-than` to silently misfilter by the user's UTC offset and triggers a `DeprecationWarning` on Python 3.12+ for calling `datetime.fromtimestamp()` without a timezone.

**Fix:**
- Pass `tz=timezone.utc` to `datetime.fromtimestamp()` in all 11 detectors
- Remove the `.replace(tzinfo=timezone.utc)` workaround in `_filter_envs()`
- Update test fixtures to use timezone-aware datetimes

All 164 existing tests pass. No new lint warnings.

// ticktockbent