### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Tlaloc-Es/killpy/security/code-scanning/1](https://github.com/Tlaloc-Es/killpy/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/test.yml` at the workflow root so it applies to all jobs unless overridden.  
For this workflow, the minimal safe setting is:

- `contents: read`

This preserves current behavior (checkout and test steps) while enforcing least privilege for `GITHUB_TOKEN`. No imports, methods, or dependencies are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
