### PR TITLE
refactor!: correct last_accessed→last_modified semantics; drop dead r…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,9 +122,9 @@ See `docs/user-guide/cli.md` for the authoritative, detailed reference.
 
 The shared contract is the `Environment` dataclass (`models.py`), not tuples:
 
-- `path: Path`, `name: str`, `type: str`, `last_accessed: datetime`,
+- `path: Path`, `name: str`, `type: str`, `last_modified: datetime`,
   `size_bytes: int`, `managed_by: str | None`, `is_system_critical: bool`
-- `size_human` and `last_accessed_str` are computed `@property` values;
+- `size_human` and `last_modified_str` are computed `@property` values;
   `to_dict()` produces the JSON contract used by `list`/`find`/`doctor --json`.
 
 The TUI (`cli.py`) stores rows as `VenvRow` / `PipxRow` `TypedDict`s at render

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Environments flagged with `⚠️` are actively in use (the environment killpy r
 | Key | Action |
 |-----|--------|
 | `↑` / `↓` or `k` / `j` | Move cursor up / down (vim-style) |
-| `/` | Open live search/filter bar (regex supported) |
+| `/` | Open live search/filter bar (substring match) |
 | `Escape` | Close search bar and clear filter |
 | `T` | Toggle multi-select mode on / off |
 | `Space` | *(Multi-select)* Toggle current row selected |
@@ -182,7 +182,7 @@ Environments flagged with `⚠️` are actively in use (the environment killpy r
 
 ### Search / filter
 
-Press `/` to open the filter bar at the bottom of the screen. Type any string or a Python regex — the venv table updates live as you type. Press `Escape` or submit an empty value to clear the filter and return to the full list.
+Press `/` to open the filter bar at the bottom of the screen. Type any text — the venv table filters by path substring (case-insensitive) and updates live as you type. Press `Escape` or submit an empty value to clear the filter and return to the full list.
 
 ### Multi-select mode
 
@@ -236,7 +236,7 @@ ______________________________________________________________________
 killpy list                               # list all detected environments
 killpy list --path ~/projects             # scan a specific path
 killpy list --type venv --type conda      # filter by type (repeatable)
-killpy list --older-than 90               # not accessed in the last 90 days
+killpy list --older-than 90               # not modified in the last 90 days
 killpy list --json                        # output as a JSON array
 killpy list --json-stream                 # stream as NDJSON — one line per env
 killpy list --quiet                       # suppress progress output (scripts/CI)
@@ -255,7 +255,7 @@ The **Path** column mirrors the form of `--path`: a relative `--path` produces r
     "absolute_path": "/home/user/projects/my-app/.venv",
     "name": "my-app/.venv",
     "type": "venv",
-    "last_accessed": "2025-11-02T14:23:01+00:00",
+    "last_modified": "2025-11-02T14:23:01+00:00",
     "size_bytes": 54393984,
     "size_human": "51.88 MB",
     "managed_by": null,
@@ -388,8 +388,7 @@ Category is assigned deterministically by applying the following rules in order:
 |----------|------|----------|
 | 1 | Orphan (`is_orphan=True`) **and** `age ≥ 180 days` | `HIGH` |
 | 2 | Active git repository **or** `age < 120 days` | `LOW` |
-| 3 | `age ≥ 120 days` | `MEDIUM` |
-| 4 | Fallback | `LOW` |
+| 3 | `age ≥ 120 days` *(exhaustive fallback)* | `MEDIUM` |
 
 Age and orphan status are the dominant signals. Size does not affect the category.
 
@@ -469,7 +468,7 @@ Yes. Run `killpy --path ~` to scan your home folder. The `stats` command gives a
 killpy delete --type venv --older-than 90 --yes
 ```
 
-Deletes every `.venv` / `pyvenv.cfg` env not accessed in the last 90 days, without prompting.
+Deletes every `.venv` / `pyvenv.cfg` env not modified in the last 90 days, without prompting.
 
 **How do I use killpy in a CI pipeline or script?**
 

--- a/dev-docs/ADDING_A_DETECTOR.md
+++ b/dev-docs/ADDING_A_DETECTOR.md
@@ -152,7 +152,7 @@ class FooDetector(AbstractDetector):
                             path=env_dir,
                             name=env_dir.name,
                             type="foo",
-                            last_accessed=datetime.fromtimestamp(
+                            last_modified=datetime.fromtimestamp(
                                 stat.st_mtime, tz=timezone.utc
                             ),
                             size_bytes=get_total_size(env_dir),

--- a/dev-docs/ARCHITECTURE_ANALYSIS.md
+++ b/dev-docs/ARCHITECTURE_ANALYSIS.md
@@ -99,7 +99,7 @@ Defines every shared data shape in the project: `Environment`, `GitInfo`,
 
 - Single-file contract means the boundary between layers is obvious.
 - `to_dict()` serialisation lives here, keeping JSON output consistent.
-- `size_human` and `last_accessed_str` as `@property` avoids duplication in
+- `size_human` and `last_modified_str` as `@property` avoids duplication in
   display code.
 
 ### Problems

--- a/dev-docs/CODING_CONVENTIONS.md
+++ b/dev-docs/CODING_CONVENTIONS.md
@@ -452,7 +452,7 @@ All shared shapes are dataclasses in `models.py`: `Environment`, `GitInfo`,
 - Closed-set string fields use `typing.Literal`: `Suggestion.category` is
   `Literal["HIGH", "MEDIUM", "LOW"]`. `Environment.type` and
   `Environment.managed_by` are open `str` / `str | None` (many/extensible values).
-- Computed display values are `@property` (`size_human`, `last_accessed_str`),
+- Computed display values are `@property` (`size_human`, `last_modified_str`),
   never duplicated in callers.
 - Construct `Environment` directly in each detector. Two filesystem detectors
   use a local `_make_env` / `_make_cache_env` factory; that is a per-module

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -95,8 +95,7 @@ The score determines *sort order* within each category. It does **not** determin
 
 1. **HIGH** — `is_orphan == True` and `age ≥ 180 days`
 1. **LOW** — `git.is_active == True` or `age < 120 days`
-1. **MEDIUM** — `age ≥ 120 days`
-1. **LOW** — fallback
+1. **MEDIUM** — `age ≥ 120 days` *(exhaustive fallback)*
 
 Age and orphan status dominate. Size does not affect classification.
 

--- a/docs/reference/json-output.md
+++ b/docs/reference/json-output.md
@@ -19,7 +19,7 @@ Example shape:
     "absolute_path": "/home/user/projects/demo/.venv",
     "name": "/home/user/projects/demo/.venv",
     "type": "venv",
-    "last_accessed": "2026-04-02T10:00:00",
+    "last_modified": "2026-04-02T10:00:00",
     "size_bytes": 183500800,
     "size_human": "175.0 MB",
     "managed_by": null,
@@ -39,7 +39,7 @@ This emits one JSON object per line as results become available.
 Example:
 
 ```json
-{"path": "projects/demo/.venv", "absolute_path": "/home/user/projects/demo/.venv", "name": "/home/user/projects/demo/.venv", "type": "venv", "last_accessed": "2026-04-02T10:00:00", "size_bytes": 183500800, "size_human": "175.0 MB", "managed_by": null, "is_system_critical": false}
+{"path": "projects/demo/.venv", "absolute_path": "/home/user/projects/demo/.venv", "name": "/home/user/projects/demo/.venv", "type": "venv", "last_modified": "2026-04-02T10:00:00", "size_bytes": 183500800, "size_human": "175.0 MB", "managed_by": null, "is_system_critical": false}
 ```
 
 NDJSON is useful when you want to pipe results into `jq` or process them incrementally.
@@ -61,7 +61,7 @@ Example shape:
     "absolute_path": "/home/user/projects/api/.venv",
     "name": "/home/user/projects/api/.venv",
     "type": "venv",
-    "last_accessed": "2026-04-02T10:00:00",
+    "last_modified": "2026-04-02T10:00:00",
     "size_bytes": 183500800,
     "size_human": "175.0 MB",
     "managed_by": null,

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -153,8 +153,7 @@ The category is assigned deterministically by evaluating rules in order:
 |----------|-----------|----------|
 | 1 | `is_orphan == True` **and** `age ≥ 180 days` | `HIGH` |
 | 2 | `git.is_active == True` **or** `age < 120 days` | `LOW` |
-| 3 | `age ≥ 120 days` | `MEDIUM` |
-| 4 | *(fallback)* | `LOW` |
+| 3 | `age ≥ 120 days` *(exhaustive fallback)* | `MEDIUM` |
 
 Age and orphan status dominate. Size has **no effect** on the category.
 
@@ -170,7 +169,7 @@ Environments are classified into three categories:
 |----------|---------|
 | `HIGH` | Delete — unused and orphaned (age + orphan status dominate). |
 | `MEDIUM` | Review — possibly unused (moderately stale, no strong active signal). |
-| `LOW` | Keep — actively used or recently accessed. |
+| `LOW` | Keep — active git repo or recently modified. |
 
 ### Default output
 

--- a/docs/user-guide/filtering-and-selection.md
+++ b/docs/user-guide/filtering-and-selection.md
@@ -19,11 +19,13 @@ killpy list --older-than 90
 killpy delete --older-than 180 --dry-run
 ```
 
-This filter is based on the recorded last-accessed timestamp stored in each `Environment` object.
+This filter is based on the recorded last-modified timestamp (`st_mtime`) stored in each `Environment` object.
 
-## Regex filtering in the TUI
+## Path filtering in the TUI
 
-Press `/` in the TUI to filter visible rows by path. The filter uses regular expressions and updates the environment table live.
+Press `/` in the TUI to filter visible rows by path. The filter is a
+case-insensitive substring match and updates the environment table live as you
+type.
 
 Examples:
 
@@ -32,10 +34,11 @@ django
 ```
 
 ```text
-/(api|worker|etl)/
+projects/api
 ```
 
-If the regex is invalid, the TUI falls back to showing all rows.
+Any row whose path contains the typed text is kept; an empty query shows all
+rows.
 
 ## Multi-select workflow
 

--- a/docs/user-guide/tui.md
+++ b/docs/user-guide/tui.md
@@ -16,7 +16,7 @@ The TUI starts with an empty table and updates progressively while detector task
 ## Keyboard shortcuts
 
 - `j` / `k`: move the cursor
-- `/`: open the regex path filter
+- `/`: open the path filter (substring match)
 - `Escape`: clear and close the filter input
 - `d`: mark an environment for deletion
 - `Ctrl+d`: delete marked rows or all selected rows in multi-select mode

--- a/killpy/cli.py
+++ b/killpy/cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import re
 import subprocess
 import sys
 from datetime import datetime
@@ -297,7 +296,7 @@ class TableApp(App):
         yield Label("", id="status-label")
         yield Label("", id="selected-path-label")
         yield Input(
-            placeholder="Filter by path (regex)… Esc to clear",
+            placeholder="Filter by path… Esc to clear",
             id="search-input",
         )
         yield Label("", id="multi-select-label")
@@ -337,7 +336,7 @@ class TableApp(App):
             {
                 "path": str(environment.path),
                 "type": environment.type,
-                "last_modified": environment.last_accessed_str,
+                "last_modified": environment.last_modified_str,
                 "size": environment.size_bytes,
                 "size_human": environment.size_human,
                 "health": self._health_by_path.get(str(environment.path), ""),
@@ -382,13 +381,10 @@ class TableApp(App):
         table.clear(columns=True)
         table.add_columns(*self.get_headers_for_table("venv-table"))
         self._venv_display_indices = []
+        query = self._filter_query.lower()
         for i, row in enumerate(self.venv_rows):
-            if self._filter_query:
-                try:
-                    if not re.search(self._filter_query, row["path"], re.IGNORECASE):
-                        continue
-                except re.error:
-                    pass  # invalid regex — show all
+            if query and query not in row["path"].lower():
+                continue
             self._venv_display_indices.append(i)
             env = row["environment"]
             type_label = ("\u26a0\ufe0f " if env.is_system_critical else "") + row[

--- a/killpy/commands/_utils.py
+++ b/killpy/commands/_utils.py
@@ -68,7 +68,7 @@ def filter_envs(
         names such as ``"venv"`` and ``"cache"`` are automatically expanded to
         their concrete sub-type values via :data:`_TYPE_ALIASES`.
     older_than:
-        If provided, only environments not accessed in the last *older_than* days
+        If provided, only environments not modified in the last *older_than* days
         are kept.
     """
     now = datetime.now(tz=timezone.utc)
@@ -84,6 +84,6 @@ def filter_envs(
 
     if older_than is not None:
         cutoff = now - timedelta(days=older_than)
-        result = [e for e in result if e.last_accessed < cutoff]
+        result = [e for e in result if e.last_modified < cutoff]
 
     return result

--- a/killpy/commands/delete.py
+++ b/killpy/commands/delete.py
@@ -37,7 +37,7 @@ from killpy.scanner import Scanner
     type=int,
     default=None,
     metavar="DAYS",
-    help="Only delete environments not accessed in the last N days.",
+    help="Only delete environments not modified in the last N days.",
 )
 @click.option(
     "--dry-run",

--- a/killpy/commands/doctor.py
+++ b/killpy/commands/doctor.py
@@ -195,7 +195,7 @@ def _output_rich(
 
         now = datetime.now(tz=timezone.utc)
         for se in top:
-            la = se.env.last_accessed
+            la = se.env.last_modified
             if la.tzinfo is None:
                 la = la.replace(tzinfo=timezone.utc)
             age_days = (now - la).days
@@ -264,7 +264,7 @@ def _print_category_table(
 
     now = datetime.now(tz=timezone.utc)
     for se in scored_envs:
-        la = se.env.last_accessed
+        la = se.env.last_modified
         if la.tzinfo is None:
             la = la.replace(tzinfo=timezone.utc)
         age_days = (now - la).days

--- a/killpy/commands/list.py
+++ b/killpy/commands/list.py
@@ -58,7 +58,7 @@ def _print_table(envs: list, console: Console) -> None:
     table = Table(show_header=True, header_style="bold cyan")
     table.add_column("Type", style="dim", min_width=10)
     table.add_column("Name", min_width=20)
-    table.add_column("Last accessed", min_width=12)
+    table.add_column("Last modified", min_width=12)
     table.add_column("Size", justify="right", min_width=9)
     table.add_column("Path")
 
@@ -66,7 +66,7 @@ def _print_table(envs: list, console: Console) -> None:
         table.add_row(
             env.type,
             env.name,
-            env.last_accessed_str,
+            env.last_modified_str,
             env.size_human,
             str(env.path),
         )
@@ -101,7 +101,7 @@ def _print_table(envs: list, console: Console) -> None:
     type=int,
     default=None,
     metavar="DAYS",
-    help="Only show environments not accessed in the last N days.",
+    help="Only show environments not modified in the last N days.",
 )
 @click.option(
     "--json-stream",

--- a/killpy/detectors/artifacts.py
+++ b/killpy/detectors/artifacts.py
@@ -69,7 +69,7 @@ class ArtifactsDetector(AbstractDetector):
                                 path=artifact_path,
                                 name=str(artifact_path),
                                 type="artifacts",
-                                last_accessed=mtime,
+                                last_modified=mtime,
                                 size_bytes=size,
                             )
                         )

--- a/killpy/detectors/cache.py
+++ b/killpy/detectors/cache.py
@@ -147,6 +147,6 @@ def _make_cache_env(cache_path: Path, tag: str) -> Environment:
         path=cache_path,
         name=str(cache_path),
         type=tag,
-        last_accessed=mtime,
+        last_modified=mtime,
         size_bytes=size,
     )

--- a/killpy/detectors/conda.py
+++ b/killpy/detectors/conda.py
@@ -97,7 +97,7 @@ class CondaDetector(AbstractDetector):
                         path=env_path,
                         name=env_name,
                         type="conda",
-                        last_accessed=mtime,
+                        last_modified=mtime,
                         size_bytes=size,
                         managed_by="conda",
                     )

--- a/killpy/detectors/hatch.py
+++ b/killpy/detectors/hatch.py
@@ -73,7 +73,7 @@ class HatchDetector(AbstractDetector):
                                 path=env_dir,
                                 name=f"{project_dir.name}/{env_dir.name}",
                                 type="hatch",
-                                last_accessed=mtime,
+                                last_modified=mtime,
                                 size_bytes=size,
                             )
                         )

--- a/killpy/detectors/pipenv.py
+++ b/killpy/detectors/pipenv.py
@@ -62,7 +62,7 @@ class PipenvDetector(AbstractDetector):
                             path=venv_path,
                             name=venv_path.name,
                             type="pipenv",
-                            last_accessed=mtime,
+                            last_modified=mtime,
                             size_bytes=size,
                         )
                     )

--- a/killpy/detectors/pipx.py
+++ b/killpy/detectors/pipx.py
@@ -126,7 +126,7 @@ class PipxDetector(AbstractDetector):
                         path=candidate,
                         name=package_name,
                         type="pipx",
-                        last_accessed=mtime,
+                        last_modified=mtime,
                         size_bytes=size,
                         managed_by="pipx",
                     )

--- a/killpy/detectors/poetry.py
+++ b/killpy/detectors/poetry.py
@@ -72,7 +72,7 @@ class PoetryDetector(AbstractDetector):
                             path=venv_path,
                             name=venv_path.name,
                             type="poetry",
-                            last_accessed=mtime,
+                            last_modified=mtime,
                             size_bytes=size,
                         )
                     )

--- a/killpy/detectors/pyenv.py
+++ b/killpy/detectors/pyenv.py
@@ -68,7 +68,7 @@ class PyenvDetector(AbstractDetector):
                             path=version_dir,
                             name=version_dir.name,
                             type="pyenv",
-                            last_accessed=mtime,
+                            last_modified=mtime,
                             size_bytes=size,
                         )
                     )

--- a/killpy/detectors/tox.py
+++ b/killpy/detectors/tox.py
@@ -42,7 +42,7 @@ class ToxDetector(AbstractDetector):
                                 path=tox_path,
                                 name=str(tox_path),
                                 type="tox",
-                                last_accessed=mtime,
+                                last_modified=mtime,
                                 size_bytes=size,
                             )
                         )

--- a/killpy/detectors/uv.py
+++ b/killpy/detectors/uv.py
@@ -81,7 +81,7 @@ class UvDetector(AbstractDetector):
                             path=env_dir,
                             name=env_dir.name,
                             type="uv",
-                            last_accessed=mtime,
+                            last_modified=mtime,
                             size_bytes=size,
                             managed_by=managed_by,
                         )

--- a/killpy/detectors/venv.py
+++ b/killpy/detectors/venv.py
@@ -105,6 +105,6 @@ def _make_env(dir_path: Path, tag: str) -> Environment:
         path=dir_path,
         name=str(dir_path),
         type=tag,
-        last_accessed=mtime,
+        last_modified=mtime,
         size_bytes=size,
     )

--- a/killpy/intelligence/scoring.py
+++ b/killpy/intelligence/scoring.py
@@ -69,8 +69,8 @@ class ScoringService:
         size_score = self._normalize_size(env.size_bytes)
         explanation.append(f"Size: {env.size_human}")
 
-        age_score, age_days = self._normalize_age(env.last_accessed)
-        explanation.append(f"Last accessed {age_days} days ago")
+        age_score, age_days = self._normalize_age(env.last_modified)
+        explanation.append(f"Last modified {age_days} days ago")
 
         is_orphan, orphan_score = self._orphan_score(env.path)
         has_project_files = not is_orphan
@@ -132,11 +132,11 @@ class ScoringService:
         return 1.0 / (1.0 + math.exp(-k * (size_bytes - x0)))
 
     @staticmethod
-    def _normalize_age(last_accessed: datetime) -> tuple[float, int]:
+    def _normalize_age(last_modified: datetime) -> tuple[float, int]:
         """Return (age_score, age_days) where age_score is linear [0, 1]."""
         now = datetime.now(tz=timezone.utc)
         try:
-            la = last_accessed
+            la = last_modified
             if la.tzinfo is None:
                 la = la.replace(tzinfo=timezone.utc)
             age_days = max(0, (now - la).days)

--- a/killpy/intelligence/suggestions.py
+++ b/killpy/intelligence/suggestions.py
@@ -9,8 +9,9 @@ from killpy.models import ScoredEnvironment, Suggestion
 
 # Age thresholds in days.
 _HIGH_AGE_ORPHAN_THRESHOLD = 180  # orphan + age >= this → HIGH
-_MEDIUM_AGE_THRESHOLD = 120  # age >= this → MEDIUM
-_LOW_AGE_THRESHOLD = 120  # age < this → LOW
+# Single LOW/MEDIUM cutoff: age < this → LOW (recently modified), age >= this →
+# MEDIUM (stale). Active git always forces LOW regardless of age.
+_STALE_AGE_THRESHOLD = 120
 
 _ACTION_HIGH = "Delete — unused and orphaned"
 _ACTION_MEDIUM = "Review — possibly unused"
@@ -59,8 +60,8 @@ class SuggestionEngine:
 
     @staticmethod
     def _age_days(scored: ScoredEnvironment) -> int:
-        """Return age in days based on env.last_accessed."""
-        la = scored.env.last_accessed
+        """Return age in days based on env.last_modified."""
+        la = scored.env.last_modified
         if la.tzinfo is None:
             la = la.replace(tzinfo=timezone.utc)
         return max(0, (datetime.now(tz=timezone.utc) - la).days)
@@ -81,32 +82,27 @@ class SuggestionEngine:
         # ── Rule 1: HIGH — orphan and stale ────────────────────────────────────
         if is_orphan and age_days >= _HIGH_AGE_ORPHAN_THRESHOLD:
             reasons.append("Orphan — no project files found nearby")
-            reasons.append(f"Not used in {age_days} days")
+            reasons.append(f"Not modified in {age_days} days")
             return "HIGH", _ACTION_HIGH
 
         # ── Rule 2: LOW — active git or very recent ─────────────────────────────
-        if is_active_git or age_days < _LOW_AGE_THRESHOLD:
+        if is_active_git or age_days < _STALE_AGE_THRESHOLD:
             if is_active_git:
                 reasons.append("Active git repository")
-            if age_days < _LOW_AGE_THRESHOLD:
-                reasons.append(f"Recently used ({age_days} days ago)")
+            if age_days < _STALE_AGE_THRESHOLD:
+                reasons.append(f"Recently modified ({age_days} days ago)")
             action = _ACTION_LOW_ACTIVE if is_active_git else _ACTION_LOW
             return "LOW", action
 
-        # ── Rule 3: MEDIUM — moderately old ────────────────────────────────────
-        if age_days >= _MEDIUM_AGE_THRESHOLD:
-            if is_orphan:
-                reasons.append("Orphan — no project files found nearby")
-            reasons.append(f"Not used in {age_days} days")
-            if (
-                scored.git_info is not None
-                and scored.git_info.is_git_repo
-                and not scored.git_info.is_active
-            ):
-                reasons.append("Associated git repo has no recent commits")
-            return "MEDIUM", _ACTION_MEDIUM
-
-        # ── Rule 4: FALLBACK → LOW ──────────────────────────────────────────────
-        if is_active_git:
-            reasons.append("Active git repository")
-        return "LOW", _ACTION_LOW
+        # ── Rule 3: MEDIUM — stale (not active, age >= _STALE_AGE_THRESHOLD) ────
+        # Exhaustive fallback: everything not caught by Rules 1–2 is stale.
+        if is_orphan:
+            reasons.append("Orphan — no project files found nearby")
+        reasons.append(f"Not modified in {age_days} days")
+        if (
+            scored.git_info is not None
+            and scored.git_info.is_git_repo
+            and not scored.git_info.is_active
+        ):
+            reasons.append("Associated git repo has no recent commits")
+        return "MEDIUM", _ACTION_MEDIUM

--- a/killpy/models.py
+++ b/killpy/models.py
@@ -35,8 +35,9 @@ class Environment:
     type:
         Short detector tag, e.g. ``"venv"``, ``"pyvenv.cfg"``, ``"poetry"``,
         ``"conda"``, ``"pipx"``, ``"cache"``, ``"uv"``, ``"artifacts"``…
-    last_accessed:
-        Timestamp of the last modification reported by the filesystem.
+    last_modified:
+        Last modification time (``st_mtime``) of the environment root, as
+        reported by the filesystem — not an access time.
     size_bytes:
         Total size in bytes (recursive directory sum).
     managed_by:
@@ -48,7 +49,7 @@ class Environment:
     path: Path
     name: str
     type: str
-    last_accessed: datetime
+    last_modified: datetime
     size_bytes: int
     managed_by: str | None = None
     is_system_critical: bool = False
@@ -63,9 +64,9 @@ class Environment:
         return format_size(self.size_bytes)
 
     @property
-    def last_accessed_str(self) -> str:
+    def last_modified_str(self) -> str:
         """Formatted date string ``DD/MM/YYYY`` for display."""
-        return self.last_accessed.strftime("%d/%m/%Y")
+        return self.last_modified.strftime("%d/%m/%Y")
 
     # ------------------------------------------------------------------ #
     #  Serialisation                                                       #
@@ -83,7 +84,7 @@ class Environment:
             "absolute_path": str(abs_path),
             "name": self.name,
             "type": self.type,
-            "last_accessed": self.last_accessed.isoformat(),
+            "last_modified": self.last_modified.isoformat(),
             "size_bytes": self.size_bytes,
             "size_human": self.size_human,
             "managed_by": self.managed_by,

--- a/tests/unit/test_cleaner.py
+++ b/tests/unit/test_cleaner.py
@@ -32,7 +32,7 @@ def _env(
         path=path or Path("/fake/env"),
         name=name,
         type=env_type,
-        last_accessed=datetime(2024, 6, 1, tzinfo=timezone.utc),
+        last_modified=datetime(2024, 6, 1, tzinfo=timezone.utc),
         size_bytes=size,
         managed_by=managed_by,
         is_system_critical=critical,

--- a/tests/unit/test_cli_multiselect.py
+++ b/tests/unit/test_cli_multiselect.py
@@ -34,7 +34,7 @@ def _make_env(path: str, size: int, critical: bool = False) -> Environment:
         path=Path(path),
         name=path,
         type=".venv",
-        last_accessed=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
         size_bytes=size,
         is_system_critical=critical,
     )
@@ -50,11 +50,8 @@ def _make_app(tmp_path: Path) -> tuple[TableApp, RecordingCleaner]:
 
 
 def test_multi_select_deletes_selected_env_after_sort(tmp_path: Path) -> None:
-    """Sorting columns must not change which environments get deleted.
-
-    Regression test: the selection used to be stored as positional indices
-    into ``venv_rows``; sorting reordered the list in place, so Ctrl+D
-    deleted whatever environments landed on the selected positions.
+    """Sorting columns must not change which environments get deleted:
+    selections are keyed by path, not by row position.
     """
 
     async def scenario() -> None:

--- a/tests/unit/test_cli_pipx.py
+++ b/tests/unit/test_cli_pipx.py
@@ -21,18 +21,14 @@ def _make_pipx_env(name: str, size: int) -> Environment:
         path=Path(f"/data/pipx/venvs/{name}"),
         name=name,
         type="pipx",
-        last_accessed=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
         size_bytes=size,
         managed_by="pipx",
     )
 
 
 def test_uninstall_pipx_from_pipx_tab(tmp_path: Path) -> None:
-    """Pressing ``U`` on the pipx tab must uninstall the highlighted package.
-
-    Regression test: ``delete_environment`` used to be gated behind the
-    venv tab, so calling it from the pipx tab silently did nothing.
-    """
+    """Pressing ``U`` on the pipx tab must uninstall the highlighted package."""
 
     async def scenario() -> None:
         app, cleaner = _make_app(tmp_path)

--- a/tests/unit/test_command_output.py
+++ b/tests/unit/test_command_output.py
@@ -48,7 +48,7 @@ def _env(
         path=Path(f"/fake/{name}"),
         name=name,
         type=env_type,
-        last_accessed=la,
+        last_modified=la,
         size_bytes=size,
     )
 

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -35,7 +35,7 @@ def _env(
         path=path or Path("/fake/myenv"),
         name=name,
         type=env_type,
-        last_accessed=datetime(2024, 3, 15, tzinfo=timezone.utc),
+        last_modified=datetime(2024, 3, 15, tzinfo=timezone.utc),
         size_bytes=size,
         managed_by=managed_by,
         is_system_critical=critical,
@@ -290,7 +290,7 @@ class TestDeleteFilters:
 
     def test_older_than_filter(self) -> None:
         old = _env(name="old", env_type="venv")
-        # last_accessed is datetime(2024, 3, 15, tzinfo=utc) — more than 30 days ago
+        # last_modified is datetime(2024, 3, 15, tzinfo=utc) — more than 30 days ago
         result = self._run_delete(["--older-than", "1", "--yes"], [old])
         assert result.exit_code == 0
 

--- a/tests/unit/test_delete_all.py
+++ b/tests/unit/test_delete_all.py
@@ -22,7 +22,7 @@ def _make_env(path: str, size: int, critical: bool = False) -> Environment:
         path=Path(path),
         name=path,
         type=".venv",
-        last_accessed=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
         size_bytes=size,
         is_system_critical=critical,
     )
@@ -72,11 +72,7 @@ def test_delete_all_continues_after_a_failed_deletion(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """A CleanerError must not abort the loop; it is reported and counted.
-
-    Regression test: the error used to propagate as an uncaught traceback,
-    aborting the mass deletion halfway with no summary.
-    """
+    """A CleanerError must not abort the loop; it is reported and counted."""
     env_ok1 = _make_env("/data/a/.venv", 10)
     env_bad = _make_env("/data/b/.venv", 20)
     env_ok2 = _make_env("/data/c/.venv", 30)
@@ -107,12 +103,7 @@ def test_delete_all_counts_zero_byte_env_as_deleted(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """An empty (0-byte) environment is a successful deletion, not a failure.
-
-    Regression test: the return value of ``Cleaner.delete`` (bytes freed)
-    was treated as a success flag, so 0-byte environments were reported
-    as 'Failed to delete'.
-    """
+    """An empty (0-byte) environment is a successful deletion, not a failure."""
     env_empty = _make_env("/data/empty/.venv", 0)
     deleted = _patch_pipeline(monkeypatch, tmp_path, [env_empty])
 

--- a/tests/unit/test_detectors.py
+++ b/tests/unit/test_detectors.py
@@ -98,7 +98,7 @@ class TestVenvDetector:
         env = envs[0]
         assert isinstance(env, Environment)
         assert isinstance(env.path, Path)
-        assert isinstance(env.last_accessed, datetime)
+        assert isinstance(env.last_modified, datetime)
         assert env.size_bytes >= 0
         assert env.size_human  # non-empty string
 

--- a/tests/unit/test_find.py
+++ b/tests/unit/test_find.py
@@ -28,7 +28,7 @@ def _env(path: Path | None = None, env_type: str = "venv") -> Environment:
         path=path or Path("/fake/myenv"),
         name="myenv",
         type=env_type,
-        last_accessed=datetime(2024, 3, 15, tzinfo=timezone.utc),
+        last_modified=datetime(2024, 3, 15, tzinfo=timezone.utc),
         size_bytes=1024,
     )
 

--- a/tests/unit/test_scanner.py
+++ b/tests/unit/test_scanner.py
@@ -25,7 +25,7 @@ def _make_env(path: Path, env_type: str = "venv", size: int = 1024) -> Environme
         path=path,
         name=path.name,
         type=env_type,
-        last_accessed=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
         size_bytes=size,
     )
 

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -17,13 +17,13 @@ def _env(
     path: Path | None = None,
     name: str = "test-env",
     size: int = 100 * 1024 * 1024,  # 100 MB
-    last_accessed: datetime | None = None,
+    last_modified: datetime | None = None,
 ) -> Environment:
     return Environment(
         path=path or Path("/fake/test-env"),
         name=name,
         type="venv",
-        last_accessed=last_accessed or datetime(2023, 1, 1, tzinfo=timezone.utc),
+        last_modified=last_modified or datetime(2023, 1, 1, tzinfo=timezone.utc),
         size_bytes=size,
         managed_by=None,
     )
@@ -63,21 +63,21 @@ class TestNormalizeSize:
 
 
 class TestNormalizeAge:
-    def test_just_accessed_gives_zero(self) -> None:
-        la = datetime.now(tz=timezone.utc)
-        score, days = ScoringService._normalize_age(la)
+    def test_just_modified_gives_zero(self) -> None:
+        lm = datetime.now(tz=timezone.utc)
+        score, days = ScoringService._normalize_age(lm)
         assert score < 0.01
         assert days == 0
 
     def test_365_days_gives_one(self) -> None:
-        la = datetime.now(tz=timezone.utc) - timedelta(days=365)
-        score, days = ScoringService._normalize_age(la)
+        lm = datetime.now(tz=timezone.utc) - timedelta(days=365)
+        score, days = ScoringService._normalize_age(lm)
         assert abs(score - 1.0) < 0.01
         assert days == 365
 
     def test_beyond_365_caps_at_one(self) -> None:
-        la = datetime.now(tz=timezone.utc) - timedelta(days=800)
-        score, _ = ScoringService._normalize_age(la)
+        lm = datetime.now(tz=timezone.utc) - timedelta(days=800)
+        score, _ = ScoringService._normalize_age(lm)
         assert score == 1.0
 
 
@@ -186,7 +186,7 @@ class TestScoreAll:
         tiny_new = _env(
             path=tmp_path / "b",
             size=1024,
-            last_accessed=datetime.now(tz=timezone.utc),
+            last_modified=datetime.now(tz=timezone.utc),
         )
         (tmp_path / "a").mkdir()
         (tmp_path / "b").mkdir()

--- a/tests/unit/test_suggestions.py
+++ b/tests/unit/test_suggestions.py
@@ -7,8 +7,7 @@ from pathlib import Path
 
 from killpy.intelligence.suggestions import (
     _HIGH_AGE_ORPHAN_THRESHOLD,
-    _LOW_AGE_THRESHOLD,
-    _MEDIUM_AGE_THRESHOLD,
+    _STALE_AGE_THRESHOLD,
     SuggestionEngine,
 )
 from killpy.models import Environment, GitInfo, ScoredEnvironment
@@ -29,7 +28,7 @@ def _env(
         path=path or Path("/fake/env"),
         name="env",
         type="venv",
-        last_accessed=datetime.now(tz=timezone.utc) - timedelta(days=days_old),
+        last_modified=datetime.now(tz=timezone.utc) - timedelta(days=days_old),
         size_bytes=size,
         managed_by=None,
     )
@@ -85,12 +84,7 @@ class TestHighCategory:
             assert suggestion.category == "HIGH", f"size={size}"
 
     def test_very_old_env_with_project_files_is_not_high(self) -> None:
-        """HIGH requires orphan status; age alone never reaches HIGH.
-
-        (A former "no project files and age >= 365" rule was removed: it
-        was unreachable because has_project_files is always the negation
-        of is_orphan, so rule 1 fired first for any qualifying env.)
-        """
+        """HIGH requires orphan status; age alone never reaches HIGH."""
         engine = SuggestionEngine()
         suggestion = engine.classify(
             _scored(
@@ -136,14 +130,14 @@ class TestMediumCategory:
     def test_old_non_orphan_env_is_medium(self) -> None:
         engine = SuggestionEngine()
         suggestion = engine.classify(
-            _scored(days_old=_MEDIUM_AGE_THRESHOLD, is_orphan=False, size=_LARGE)
+            _scored(days_old=_STALE_AGE_THRESHOLD, is_orphan=False, size=_LARGE)
         )
         assert suggestion.category == "MEDIUM"
 
     def test_slightly_above_medium_threshold_is_medium(self) -> None:
         engine = SuggestionEngine()
         suggestion = engine.classify(
-            _scored(days_old=_MEDIUM_AGE_THRESHOLD + 10, size=_SMALL)
+            _scored(days_old=_STALE_AGE_THRESHOLD + 10, size=_SMALL)
         )
         assert suggestion.category == "MEDIUM"
 
@@ -151,7 +145,7 @@ class TestMediumCategory:
         engine = SuggestionEngine()
         suggestion = engine.classify(
             _scored(
-                days_old=_MEDIUM_AGE_THRESHOLD + 10, git_info=_ACTIVE_GIT, size=_LARGE
+                days_old=_STALE_AGE_THRESHOLD + 10, git_info=_ACTIVE_GIT, size=_LARGE
             )
         )
         assert suggestion.category == "LOW"
@@ -163,14 +157,14 @@ class TestMediumCategory:
 
 
 class TestLowCategory:
-    def test_recently_used_with_active_git_is_low(self) -> None:
+    def test_recently_modified_with_active_git_is_low(self) -> None:
         engine = SuggestionEngine()
         suggestion = engine.classify(
             _scored(days_old=5, git_info=_ACTIVE_GIT, size=_LARGE)
         )
         assert suggestion.category == "LOW"
 
-    def test_recently_used_no_git_is_low(self) -> None:
+    def test_recently_modified_no_git_is_low(self) -> None:
         engine = SuggestionEngine()
         suggestion = engine.classify(_scored(days_old=5, size=_LARGE))
         assert suggestion.category == "LOW"
@@ -178,7 +172,7 @@ class TestLowCategory:
     def test_age_just_below_threshold_is_low(self) -> None:
         engine = SuggestionEngine()
         suggestion = engine.classify(
-            _scored(days_old=_LOW_AGE_THRESHOLD - 1, size=_LARGE)
+            _scored(days_old=_STALE_AGE_THRESHOLD - 1, size=_LARGE)
         )
         assert suggestion.category == "LOW"
 
@@ -206,7 +200,7 @@ class TestClassifyAll:
                 days_old=_HIGH_AGE_ORPHAN_THRESHOLD + 1,
                 size=_LARGE,
             ),
-            _scored(days_old=_MEDIUM_AGE_THRESHOLD + 5, score=0.2, size=_LARGE),
+            _scored(days_old=_STALE_AGE_THRESHOLD + 5, score=0.2, size=_LARGE),
         ]
         suggestions = engine.classify_all(envs)
         categories = [s.category for s in suggestions]
@@ -248,7 +242,7 @@ class TestSuggestionContent:
         engine = SuggestionEngine()
         for scored in [
             _scored(is_orphan=True, days_old=_HIGH_AGE_ORPHAN_THRESHOLD, size=_LARGE),
-            _scored(days_old=_MEDIUM_AGE_THRESHOLD + 10, score=0.2, size=_LARGE),
+            _scored(days_old=_STALE_AGE_THRESHOLD + 10, score=0.2, size=_LARGE),
             _scored(days_old=5, size=_LARGE),
         ]:
             suggestion = engine.classify(scored)
@@ -265,7 +259,7 @@ class TestSuggestionContent:
         engine = SuggestionEngine()
         for scored in [
             _scored(is_orphan=True, days_old=_HIGH_AGE_ORPHAN_THRESHOLD, size=_LARGE),
-            _scored(days_old=_MEDIUM_AGE_THRESHOLD + 10, size=_LARGE),
+            _scored(days_old=_STALE_AGE_THRESHOLD + 10, size=_LARGE),
             _scored(days_old=5, size=_SMALL),
         ]:
             for reason in engine.classify(scored).reasons:


### PR DESCRIPTION
Three related cleanups that pave the way for the shared-filesystem-walk refactor (GIT-2):

GIT-5 — the stored timestamp is always st_mtime (modification time), never an access time (no st_atime anywhere in the tree). Rename to match reality:
  * Environment.last_accessed → last_modified (property last_accessed_str → last_modified_str), across all 11 detectors and every consumer.
  * JSON output key last_accessed → last_modified.
  * "accessed"/"used" wording → "modified" in list/delete --older-than help, doctor reasons, scoring explanation, and the docs.

GIT-29 — SuggestionEngine Rule 4 was unreachable: the LOW and MEDIUM age thresholds were both 120, so Rules 2–3 partitioned the whole space and the fallback never ran. Remove it and collapse the two equal thresholds into a single _STALE_AGE_THRESHOLD. suggestions.py is now 100% covered.

GIT-7 — the TUI '/' filter compiled a user-supplied regex per row on every keystroke with no timeout: a catastrophic-backtracking pattern (e.g. (a+)+$) froze the UI. Replace with a case-insensitive substring match (drop the regex feature) and update the docs. stdlib offers no portable way to interrupt a runaway regex, so substring is the robust fix.

Also removes changelog-style/past-referencing comments and aligns the docs (rule tables no longer list the removed Rule 4; AGENTS.md / dev-docs use the new field names).

BREAKING CHANGE: the `killpy list --json` / `--json-stream` output field `last_accessed` is renamed to `last_modified`. Scripts reading that key must be updated.